### PR TITLE
SUPM-1653: Update for D11.

### DIFF
--- a/pcdora.info.yml
+++ b/pcdora.info.yml
@@ -1,7 +1,7 @@
 name: 'pcdora'
 type: module
 description: 'Providence College Customizations'
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^10 || ^11
 package: 'discoverygarden'
 dependencies:
  - drupal:migrate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Module compatibility requirements have been updated. The module now officially supports Drupal 11 and requires Drupal 10 as the minimum supported version. Drupal versions 8 and 9 are no longer compatible with this module. Verify your environment is running Drupal 10 or higher before upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->