### PR TITLE
PC2-53: Removed download link from video player menu.

### DIFF
--- a/pcdora.module
+++ b/pcdora.module
@@ -12,3 +12,12 @@ function pcdora_preprocess_node__islandora_object(&$variables) {
   // Disable right click on video.
   $variables['#attached']['library'][] = 'pcdora/pcdoravideo';
 }
+
+/**
+ * Implements hook_preprocess_hook()
+ *
+ * Removes the download option from the three-dot menu in the video player.
+ */
+function pcdora_preprocess_islandora_file_video(array &$variables): void {
+  $variables['attributes']['controlsList'] = 'nodownload';
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated video player controls to prevent downloading videos from the player menu while preserving existing right-click protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->